### PR TITLE
build: replace regex with nom parsers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["usb"]
 categories = ["hardware-support"]
 
 [build-dependencies]
+nom = { version = "6.2", default-features = false }
 phf_codegen = "0.8"
-regex = "1.4"
 quote = "1.0"
 proc-macro2 = "1.0"
 


### PR DESCRIPTION
The PR changes the compile times for me from like `11.11s` to `7.89s`.

This would probably also help implementing the other entities (#2).