### PR TITLE
Update to nom 7.0 to work with regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["usb"]
 categories = ["hardware-support"]
 
 [build-dependencies]
-nom = { version = "6.2", default-features = false }
+nom = { version = "7.0", default-features = false }
 phf_codegen = "0.9"
 quote = "1.0"
 proc-macro2 = "1.0"


### PR DESCRIPTION
The current release can't be used with the regex crate due to this issue with nom < 7.0: https://github.com/Geal/nom/issues/1330