### PR TITLE
Adds all USB IDs in the repository

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -232,7 +232,10 @@ impl ParserState {
                         devices: vec![],
                     });
                 // We should always have a current vendor; failure here indicates a malformed input.
-                } else if let Some(curr_vendor) = curr_vendor.as_mut() {
+                } else {
+                    let curr_vendor = curr_vendor
+                        .as_mut()
+                        .expect("No parent vendor whilst parsing vendors");
                     if let Ok((name, id)) = parser::device(line) {
                         curr_vendor.devices.push(CgDevice {
                             id,
@@ -245,15 +248,13 @@ impl ParserState {
                             .devices
                             .iter_mut()
                             .find(|d| d.id == *curr_device_id)
-                            .expect("No parent device whilst parsing interfaces, confirm file not malformed");
+                            .expect("No parent device whilst parsing interfaces");
 
                         curr_device.interfaces.push(CgInterface {
                             id,
                             name: name.into(),
                         });
                     }
-                } else {
-                    panic!("No parent vendor whilst parsing vendors, confirm file in correct order and not malformed: {:?}", line);
                 }
             }
             ParserState::Classes(m, ref mut curr_class, ref mut curr_class_id) => {
@@ -268,8 +269,10 @@ impl ParserState {
                         name: name.into(),
                         sub_classes: vec![],
                     });
-                // We should always have a current class; failure here indicates a malformed input.
-                } else if let Some(curr_class) = curr_class.as_mut() {
+                } else {
+                    let curr_class = curr_class
+                        .as_mut()
+                        .expect("No parent class whilst parsing classes");
                     if let Ok((name, id)) = parser::sub_class(line) {
                         curr_class.sub_classes.push(CgSubClass {
                             id,
@@ -282,91 +285,75 @@ impl ParserState {
                             .sub_classes
                             .iter_mut()
                             .find(|d| d.id == *curr_class_id)
-                            .expect("No parent sub-class whilst parsing protocols, confirm file not malformed");
+                            .expect("No parent sub-class whilst parsing protocols");
 
                         curr_device.children.push(CgProtocol {
                             id,
                             name: name.into(),
                         });
                     }
-                } else {
-                    panic!("No parent class whilst parsing classes, confirm file in correct order and not malformed: {:?}", line);
                 }
             }
             ParserState::AtType(m, ref mut current) => {
-                if let Ok((name, id)) = parser::audio_terminal_type(line) {
-                    if let Some(cv) = current {
-                        m.entry(cv.id, &quote!(#cv).to_string());
-                    }
-
-                    // Set our new class as the current class.
-                    *current = Some(CgAtType {
-                        id,
-                        name: name.into(),
-                    });
-                } else {
-                    panic!("Invalid audio terminal line: {:?}", line);
+                let (name, id) =
+                    parser::audio_terminal_type(line).expect("Invalid audio terminal line");
+                if let Some(cv) = current {
+                    m.entry(cv.id, &quote!(#cv).to_string());
                 }
+
+                // Set our new class as the current class.
+                *current = Some(CgAtType {
+                    id,
+                    name: name.into(),
+                });
             }
             ParserState::HidType(m, ref mut current) => {
-                if let Ok((name, id)) = parser::hid_type(line) {
-                    if let Some(cv) = current {
-                        m.entry(cv.id, &quote!(#cv).to_string());
-                    }
-
-                    // Set our new class as the current class.
-                    *current = Some(CgHidType {
-                        id,
-                        name: name.into(),
-                    });
-                } else {
-                    panic!("Invalid hid type line: {:?}", line);
+                let (name, id) = parser::hid_type(line).expect("Invalid hid type line");
+                if let Some(cv) = current {
+                    m.entry(cv.id, &quote!(#cv).to_string());
                 }
+
+                // Set our new class as the current class.
+                *current = Some(CgHidType {
+                    id,
+                    name: name.into(),
+                });
             }
             ParserState::RType(m, ref mut current) => {
-                if let Ok((name, id)) = parser::hid_item_type(line) {
-                    if let Some(cv) = current {
-                        m.entry(cv.id, &quote!(#cv).to_string());
-                    }
-
-                    // Set our new class as the current class.
-                    *current = Some(CgRType {
-                        id,
-                        name: name.into(),
-                    });
-                } else {
-                    panic!("Invalid hid item type line: {:?}", line);
+                let (name, id) = parser::hid_item_type(line).expect("Invalid hid item type line");
+                if let Some(cv) = current {
+                    m.entry(cv.id, &quote!(#cv).to_string());
                 }
+
+                // Set our new class as the current class.
+                *current = Some(CgRType {
+                    id,
+                    name: name.into(),
+                });
             }
             ParserState::BiasType(m, ref mut current) => {
-                if let Ok((name, id)) = parser::bias_type(line) {
-                    if let Some(cv) = current {
-                        m.entry(cv.id, &quote!(#cv).to_string());
-                    }
-
-                    // Set our new class as the current class.
-                    *current = Some(CgRBiasType {
-                        id,
-                        name: name.into(),
-                    });
-                } else {
-                    panic!("Invalid bias type line: {:?}", line);
+                let (name, id) = parser::bias_type(line).expect("Invalid bias type line");
+                if let Some(cv) = current {
+                    m.entry(cv.id, &quote!(#cv).to_string());
                 }
+
+                // Set our new class as the current class.
+                *current = Some(CgRBiasType {
+                    id,
+                    name: name.into(),
+                });
             }
             ParserState::PhyType(m, ref mut current) => {
-                if let Ok((name, id)) = parser::phy_type(line) {
-                    if let Some(cv) = current {
-                        m.entry(cv.id, &quote!(#cv).to_string());
-                    }
-
-                    // Set our new class as the current class.
-                    *current = Some(CgPhyType {
-                        id,
-                        name: name.into(),
-                    });
-                } else {
-                    panic!("Invalid phy type line: {:?}", line);
+                let (name, id) = parser::phy_type(line).expect("Invalid phy type line");
+                if let Some(cv) = current {
+                    m.entry(cv.id, &quote!(#cv).to_string());
                 }
+
+                // Set our new class as the current class.
+                *current = Some(CgPhyType {
+                    id,
+                    name: name.into(),
+                });
             }
             ParserState::HutType(m, ref mut current) => {
                 if let Ok((name, id)) = parser::hut_type(line) {
@@ -380,15 +367,14 @@ impl ParserState {
                         name: name.into(),
                         children: vec![],
                     });
-                } else if let Some(curr_hut) = current.as_mut() {
+                } else {
+                    let curr_hut = current.as_mut().expect("No parent hut whilst parsing huts");
                     if let Ok((name, id)) = parser::hid_usage_name(line) {
                         curr_hut.children.push(CgHidUsage {
                             id,
                             name: name.into(),
                         });
                     }
-                } else {
-                    panic!("No parent hut whilst parsing huts, confirm file in correct order and not malformed: {:?}", line);
                 }
             }
             ParserState::Lang(m, ref mut current) => {
@@ -403,46 +389,41 @@ impl ParserState {
                         name: name.into(),
                         children: vec![],
                     });
-                } else if let Some(curr_lang) = current.as_mut() {
+                } else {
+                    let curr_lang = current
+                        .as_mut()
+                        .expect("No parent lang whilst parsing langs");
                     if let Ok((name, id)) = parser::dialect(line) {
                         curr_lang.children.push(CgDialect {
                             id,
                             name: name.into(),
                         });
                     }
-                } else {
-                    panic!("No parent lang whilst parsing langs, confirm file in correct order and not malformed: {:?}", line);
                 }
             }
             ParserState::CountryCode(m, ref mut current) => {
-                if let Ok((name, id)) = parser::country_code(line) {
-                    if let Some(cv) = current {
-                        m.entry(cv.id, &quote!(#cv).to_string());
-                    }
-
-                    // Set our new class as the current class.
-                    *current = Some(CgCountryCode {
-                        id,
-                        name: name.into(),
-                    });
-                } else {
-                    panic!("Invalid country code line: {:?}", line);
+                let (name, id) = parser::country_code(line).expect("Invalid country code line");
+                if let Some(cv) = current {
+                    m.entry(cv.id, &quote!(#cv).to_string());
                 }
+
+                // Set our new class as the current class.
+                *current = Some(CgCountryCode {
+                    id,
+                    name: name.into(),
+                });
             }
             ParserState::TerminalType(m, ref mut current) => {
-                if let Ok((name, id)) = parser::terminal_type(line) {
-                    if let Some(cv) = current {
-                        m.entry(cv.id, &quote!(#cv).to_string());
-                    }
-
-                    // Set our new class as the current class.
-                    *current = Some(CgTerminalType {
-                        id,
-                        name: name.into(),
-                    });
-                } else {
-                    panic!("Invalid terminal type line: {:?}", line);
+                let (name, id) = parser::terminal_type(line).expect("Invalid terminal type line");
+                if let Some(cv) = current {
+                    m.entry(cv.id, &quote!(#cv).to_string());
                 }
+
+                // Set our new class as the current class.
+                *current = Some(CgTerminalType {
+                    id,
+                    name: name.into(),
+                });
             }
         }
     }

--- a/build.rs
+++ b/build.rs
@@ -11,12 +11,37 @@ use quote::quote;
  * of context needed for pairing nested entities (e.g. devices) with their parents (e.g. vendors).
  */
 
-type VMap = Map<u16>;
+const VENDOR_PROLOGUE: &str = "static USB_IDS: phf::Map<u16, Vendor> = ";
+const CLASS_PROLOGUE: &str = "static USB_CLASSES: phf::Map<u8, Class> = ";
+const AUDIO_TERMINAL_PROLOGUE: &str = "static USB_AUDIO_TERMINALS: phf::Map<u16, AudioTerminal> = ";
+const HID_ID_PROLOGUE: &str = "static USB_HID_IDS: phf::Map<u8, Hid> = ";
+const HID_R_PROLOGUE: &str = "static USB_HID_R_TYPES: phf::Map<u8, HidItemType> = ";
+const BIAS_PROLOGUE: &str = "static USB_BIASES: phf::Map<u8, Bias> = ";
+const PHY_PROLOGUE: &str = "static USB_PHYS: phf::Map<u8, Phy> = ";
+const HUT_PROLOGUE: &str = "static USB_HUTS: phf::Map<u8, HidUsagePage> = ";
+const LANG_PROLOGUE: &str = "static USB_LANGS: phf::Map<u16, Language> = ";
+const HID_CC_PROLOGUE: &str = "static USB_HID_CCS: phf::Map<u8, HidCountryCode> = ";
+const TERMINAL_PROLOGUE: &str = "static USB_VIDEO_TERMINALS: phf::Map<u16, VideoTerminal> = ";
+
+trait CgEntry<T> {
+    fn id(&self) -> T;
+    fn name(&self) -> &str;
+}
 
 struct CgVendor {
     id: u16,
     name: String,
     devices: Vec<CgDevice>,
+}
+
+impl CgEntry<u16> for CgVendor {
+    fn id(&self) -> u16 {
+        self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 struct CgDevice {
@@ -25,9 +50,471 @@ struct CgDevice {
     interfaces: Vec<CgInterface>,
 }
 
-struct CgInterface {
+impl CgEntry<u16> for CgDevice {
+    fn id(&self) -> u16 {
+        self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+struct CgClass {
     id: u8,
     name: String,
+    sub_classes: Vec<CgSubClass>,
+}
+
+type CgSubClass = CgParentType<u8, CgProtocol>;
+
+struct CgParentType<T, C> {
+    id: T,
+    name: String,
+    children: Vec<C>,
+}
+
+struct CgType<T> {
+    id: T,
+    name: String,
+}
+
+impl<T: Copy> CgEntry<T> for CgType<T> {
+    fn id(&self) -> T {
+        self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+type CgInterface = CgType<u8>;
+type CgProtocol = CgType<u8>;
+type CgAtType = CgType<u16>;
+type CgHidType = CgType<u8>;
+type CgRType = CgType<u8>;
+type CgRBiasType = CgType<u8>;
+type CgPhyType = CgType<u8>;
+
+type CgHidUsage = CgType<u16>;
+type CgHut = CgParentType<u8, CgHidUsage>;
+
+type CgDialect = CgType<u8>;
+type CgLang = CgParentType<u16, CgDialect>;
+
+type CgCountryCode = CgType<u8>;
+type CgTerminalType = CgType<u16>;
+
+/// Parser state expects file in be in this order. It's required because some
+/// parsers are ambiguous without context; device.interface == subclass.protocol for example.
+enum ParserState {
+    Vendors(Map<u16>, Option<CgVendor>, u16),
+    Classes(Map<u8>, Option<CgClass>, u8),
+    AtType(Map<u16>, Option<CgAtType>),
+    HidType(Map<u8>, Option<CgHidType>),
+    RType(Map<u8>, Option<CgRType>),
+    BiasType(Map<u8>, Option<CgRBiasType>),
+    PhyType(Map<u8>, Option<CgPhyType>),
+    HutType(Map<u8>, Option<CgHut>),
+    Lang(Map<u16>, Option<CgLang>),
+    CountryCode(Map<u8>, Option<CgCountryCode>),
+    TerminalType(Map<u16>, Option<CgTerminalType>),
+}
+
+impl ParserState {
+    /// Return the prologue string for the current state; the type definition
+    fn prologue_str(&self) -> &'static str {
+        match self {
+            ParserState::Vendors(_, _, _) => VENDOR_PROLOGUE,
+            ParserState::Classes(_, _, _) => CLASS_PROLOGUE,
+            ParserState::AtType(_, _) => AUDIO_TERMINAL_PROLOGUE,
+            ParserState::HidType(_, _) => HID_ID_PROLOGUE,
+            ParserState::RType(_, _) => HID_R_PROLOGUE,
+            ParserState::BiasType(_, _) => BIAS_PROLOGUE,
+            ParserState::PhyType(_, _) => PHY_PROLOGUE,
+            ParserState::HutType(_, _) => HUT_PROLOGUE,
+            ParserState::Lang(_, _) => LANG_PROLOGUE,
+            ParserState::CountryCode(_, _) => HID_CC_PROLOGUE,
+            ParserState::TerminalType(_, _) => TERMINAL_PROLOGUE,
+        }
+    }
+
+    /// Emit any pending entries to the map
+    fn emit(&mut self) {
+        match self {
+            ParserState::Vendors(m, Some(vendor), _) => {
+                m.entry(vendor.id, &quote!(#vendor).to_string());
+            }
+            ParserState::Classes(m, Some(class), _) => {
+                m.entry(class.id, &quote!(#class).to_string());
+            }
+            ParserState::AtType(m, Some(t)) => {
+                m.entry(t.id(), &quote!(#t).to_string());
+            }
+            ParserState::HidType(m, Some(t)) => {
+                m.entry(t.id(), &quote!(#t).to_string());
+            }
+            ParserState::RType(m, Some(t)) => {
+                m.entry(t.id(), &quote!(#t).to_string());
+            }
+            ParserState::BiasType(m, Some(t)) => {
+                m.entry(t.id(), &quote!(#t).to_string());
+            }
+            ParserState::PhyType(m, Some(t)) => {
+                m.entry(t.id(), &quote!(#t).to_string());
+            }
+            ParserState::HutType(m, Some(t)) => {
+                m.entry(t.id, &quote!(#t).to_string());
+            }
+            ParserState::Lang(m, Some(t)) => {
+                m.entry(t.id, &quote!(#t).to_string());
+            }
+            ParserState::CountryCode(m, Some(t)) => {
+                m.entry(t.id(), &quote!(#t).to_string());
+            }
+            ParserState::TerminalType(m, Some(t)) => {
+                m.entry(t.id(), &quote!(#t).to_string());
+            }
+            _ => {}
+        }
+    }
+
+    fn next_from_header(&mut self, line: &str, output: &mut impl Write) -> Option<ParserState> {
+        if line.is_empty() || !line.starts_with('#') {
+            return None;
+        }
+
+        match line {
+            "# C class  class_name" => {
+                self.finalize(output);
+                Some(ParserState::Classes(Map::<u8>::new(), None, 0u8))
+            }
+            "# AT terminal_type  terminal_type_name" => {
+                self.finalize(output);
+                Some(ParserState::AtType(Map::<u16>::new(), None))
+            }
+            "# HID descriptor_type  descriptor_type_name" => {
+                self.finalize(output);
+                Some(ParserState::HidType(Map::<u8>::new(), None))
+            }
+            "# R item_type  item_type_name" => {
+                self.finalize(output);
+                Some(ParserState::RType(Map::<u8>::new(), None))
+            }
+            "# BIAS item_type  item_type_name" => {
+                self.finalize(output);
+                Some(ParserState::BiasType(Map::<u8>::new(), None))
+            }
+            "# PHY item_type  item_type_name" => {
+                self.finalize(output);
+                Some(ParserState::PhyType(Map::<u8>::new(), None))
+            }
+            "# HUT hi  _usage_page  hid_usage_page_name" => {
+                self.finalize(output);
+                Some(ParserState::HutType(Map::<u8>::new(), None))
+            }
+            "# L language_id  language_name" => {
+                self.finalize(output);
+                Some(ParserState::Lang(Map::<u16>::new(), None))
+            }
+            "# HCC country_code keymap_type" => {
+                self.finalize(output);
+                Some(ParserState::CountryCode(Map::<u8>::new(), None))
+            }
+            "# VT terminal_type  terminal_type_name" => {
+                self.finalize(output);
+                Some(ParserState::TerminalType(Map::<u16>::new(), None))
+            }
+            _ => None
+        }
+    }
+
+    /// Process a line of input for the current state
+    fn process(&mut self, line: &str) {
+        if line.is_empty() || line.starts_with('#') {
+            return;
+        }
+
+        // Switch parser state based on line prefix and current state
+        // this relies on ordering of classes and types in the file...
+        match self {
+            ParserState::Vendors(m, ref mut curr_vendor, ref mut curr_device_id) => {
+                if let Ok((name, id)) = parser::vendor(line) {
+                    if let Some(cv) = curr_vendor {
+                        m.entry(cv.id, &quote!(#cv).to_string());
+                    }
+
+                    // Set our new vendor as the current vendor.
+                    *curr_vendor = Some(CgVendor {
+                        id,
+                        name: name.into(),
+                        devices: vec![],
+                    });
+                // We should always have a current vendor; failure here indicates a malformed input.
+                } else if let Some(curr_vendor) = curr_vendor.as_mut() {
+                    if let Ok((name, id)) = parser::device(line) {
+                        curr_vendor.devices.push(CgDevice {
+                            id,
+                            name: name.into(),
+                            interfaces: vec![],
+                        });
+                        *curr_device_id = id;
+                    } else if let Ok((name, id)) = parser::interface(line) {
+                        let curr_device = curr_vendor
+                            .devices
+                            .iter_mut()
+                            .find(|d| d.id == *curr_device_id)
+                            .expect("No parent device whilst parsing interfaces, confirm file not malformed");
+
+                        curr_device.interfaces.push(CgInterface {
+                            id,
+                            name: name.into(),
+                        });
+                    }
+                } else {
+                    panic!("No parent vendor whilst parsing vendors, confirm file in correct order and not malformed: {:?}", line);
+                }
+            }
+            ParserState::Classes(m, ref mut curr_class, ref mut curr_class_id) => {
+                if let Ok((name, id)) = parser::class(line) {
+                    if let Some(cv) = curr_class {
+                        m.entry(cv.id, &quote!(#cv).to_string());
+                    }
+
+                    // Set our new class as the current class.
+                    *curr_class = Some(CgClass {
+                        id,
+                        name: name.into(),
+                        sub_classes: vec![],
+                    });
+                // We should always have a current class; failure here indicates a malformed input.
+                } else if let Some(curr_class) = curr_class.as_mut() {
+                    if let Ok((name, id)) = parser::sub_class(line) {
+                        curr_class.sub_classes.push(CgSubClass {
+                            id,
+                            name: name.into(),
+                            children: vec![],
+                        });
+                        *curr_class_id = id;
+                    } else if let Ok((name, id)) = parser::protocol(line) {
+                        let curr_device = curr_class
+                            .sub_classes
+                            .iter_mut()
+                            .find(|d| d.id == *curr_class_id)
+                            .expect("No parent sub-class whilst parsing protocols, confirm file not malformed");
+
+                        curr_device.children.push(CgProtocol {
+                            id,
+                            name: name.into(),
+                        });
+                    }
+                } else {
+                    panic!("No parent class whilst parsing classes, confirm file in correct order and not malformed: {:?}", line);
+                }
+            },
+            ParserState::AtType(m, ref mut current) => {
+                if let Ok((name, id)) = parser::audio_terminal_type(line) {
+                    if let Some(cv) = current {
+                        m.entry(cv.id, &quote!(#cv).to_string());
+                    }
+
+                    // Set our new class as the current class.
+                    *current = Some(CgAtType {
+                        id,
+                        name: name.into(),
+                    });
+                } else {
+                    panic!("Invalid audio terminal line: {:?}", line);
+                }
+            },
+            ParserState::HidType(m, ref mut current) => {
+                if let Ok((name, id)) = parser::hid_type(line) {
+                    if let Some(cv) = current {
+                        m.entry(cv.id, &quote!(#cv).to_string());
+                    }
+
+                    // Set our new class as the current class.
+                    *current = Some(CgHidType {
+                        id,
+                        name: name.into(),
+                    });
+                } else {
+                    panic!("Invalid hid type line: {:?}", line);
+                }
+            },
+            ParserState::RType(m, ref mut current) => {
+                if let Ok((name, id)) = parser::hid_item_type(line) {
+                    if let Some(cv) = current {
+                        m.entry(cv.id, &quote!(#cv).to_string());
+                    }
+
+                    // Set our new class as the current class.
+                    *current = Some(CgRType {
+                        id,
+                        name: name.into(),
+                    });
+                } else {
+                    panic!("Invalid hid item type line: {:?}", line);
+                }
+            },
+            ParserState::BiasType(m, ref mut current) => {
+                if let Ok((name, id)) = parser::bias_type(line) {
+                    if let Some(cv) = current {
+                        m.entry(cv.id, &quote!(#cv).to_string());
+                    }
+
+                    // Set our new class as the current class.
+                    *current = Some(CgRBiasType {
+                        id,
+                        name: name.into(),
+                    });
+                } else {
+                    panic!("Invalid bias type line: {:?}", line);
+                }
+            },
+            ParserState::PhyType(m, ref mut current) => {
+                if let Ok((name, id)) = parser::phy_type(line) {
+                    if let Some(cv) = current {
+                        m.entry(cv.id, &quote!(#cv).to_string());
+                    }
+
+                    // Set our new class as the current class.
+                    *current = Some(CgPhyType {
+                        id,
+                        name: name.into(),
+                    });
+                } else {
+                    panic!("Invalid phy type line: {:?}", line);
+                }
+            },
+            ParserState::HutType(m, ref mut current) => {
+                if let Ok((name, id)) = parser::hut_type(line) {
+                    if let Some(cv) = current {
+                        m.entry(cv.id, &quote!(#cv).to_string());
+                    }
+
+                    // Set our new class as the current class.
+                    *current = Some(CgHut {
+                        id,
+                        name: name.into(),
+                        children: vec![],
+                    });
+                } else if let Some(curr_hut) = current.as_mut() {
+                    if let Ok((name, id)) = parser::hid_usage_name(line) {
+                        curr_hut.children.push(CgHidUsage {
+                            id,
+                            name: name.into(),
+                        });
+                    }
+                } else {
+                    panic!("No parent hut whilst parsing huts, confirm file in correct order and not malformed: {:?}", line);
+                }
+            },
+            ParserState::Lang(m, ref mut current) => {
+                if let Ok((name, id)) = parser::language(line) {
+                    if let Some(cv) = current {
+                        m.entry(cv.id, &quote!(#cv).to_string());
+                    }
+
+                    // Set our new class as the current class.
+                    *current = Some(CgLang {
+                        id,
+                        name: name.into(),
+                        children: vec![],
+                    });
+                } else if let Some(curr_lang) = current.as_mut() {
+                    if let Ok((name, id)) = parser::dialect(line) {
+                        curr_lang.children.push(CgDialect {
+                            id,
+                            name: name.into(),
+                        });
+                    }
+                } else {
+                    panic!("No parent lang whilst parsing langs, confirm file in correct order and not malformed: {:?}", line);
+                }
+            },
+            ParserState::CountryCode(m, ref mut current) => {
+                if let Ok((name, id)) = parser::country_code(line) {
+                    if let Some(cv) = current {
+                        m.entry(cv.id, &quote!(#cv).to_string());
+                    }
+
+                    // Set our new class as the current class.
+                    *current = Some(CgCountryCode {
+                        id,
+                        name: name.into(),
+                    });
+                } else {
+                    panic!("Invalid country code line: {:?}", line);
+                }
+            },
+            ParserState::TerminalType(m, ref mut current) => {
+                if let Ok((name, id)) = parser::terminal_type(line) {
+                    if let Some(cv) = current {
+                        m.entry(cv.id, &quote!(#cv).to_string());
+                    }
+
+                    // Set our new class as the current class.
+                    *current = Some(CgTerminalType {
+                        id,
+                        name: name.into(),
+                    });
+                } else {
+                    panic!("Invalid terminal type line: {:?}", line);
+                }
+            },
+        }
+    }
+
+    /// Emit the prologue and map to the output file
+    ///
+    /// Should be used before switching to a new state
+    fn finalize(&mut self, output: &mut impl Write) {
+        // Emit any pending contained within
+        self.emit();
+
+        // Write the prologue
+        writeln!(output, "{}", self.prologue_str()).unwrap();
+
+        // And the map itself
+        match self {
+            ParserState::Vendors(m, _, _) => {
+                writeln!(output, "{};", m.build()).unwrap();
+            }
+            ParserState::Classes(m, _, _) => {
+                writeln!(output, "{};", m.build()).unwrap();
+            }
+            ParserState::AtType(m, _) => {
+                writeln!(output, "{};", m.build()).unwrap();
+            }
+            ParserState::HidType(m, _) => {
+                writeln!(output, "{};", m.build()).unwrap();
+            }
+            ParserState::RType(m, _) => {
+                writeln!(output, "{};", m.build()).unwrap();
+            }
+            ParserState::BiasType(m, _) => {
+                writeln!(output, "{};", m.build()).unwrap();
+            }
+            ParserState::PhyType(m, _) => {
+                writeln!(output, "{};", m.build()).unwrap();
+            }
+            ParserState::HutType(m, _) => {
+                writeln!(output, "{};", m.build()).unwrap();
+            }
+            ParserState::Lang(m, _) => {
+                writeln!(output, "{};", m.build()).unwrap();
+            }
+            ParserState::CountryCode(m, _) => {
+                writeln!(output, "{};", m.build()).unwrap();
+            }
+            ParserState::TerminalType(m, _) => {
+                writeln!(output, "{};", m.build()).unwrap();
+            }
+            // _ => {}
+        }
+    }
 }
 
 #[allow(clippy::redundant_field_names)]
@@ -44,65 +531,25 @@ fn main() {
         BufWriter::new(f)
     };
 
-    // Parser state.
-    let mut curr_vendor: Option<CgVendor> = None;
-    let mut curr_device_id = 0u16;
-
-    let mut map = emit_prologue(&mut output);
+    // Parser state machine starts with vendors (first in file)
+    let mut parser_state: ParserState = ParserState::Vendors(Map::<u16>::new(), None, 0u16);
 
     for line in input.lines() {
-        let line = line.unwrap();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-
-        if let Ok((name, id)) = parser::vendor(&line) {
-            // If there was a previous vendor, emit it.
-            if let Some(vendor) = curr_vendor.take() {
-                emit_vendor(&mut map, &vendor);
+        if let Ok(line) = line {
+            if line.is_empty() {
+                continue;
             }
 
-            // Set our new vendor as the current vendor.
-            curr_vendor = Some(CgVendor {
-                id,
-                name: name.into(),
-                devices: vec![],
-            });
-        } else if let Ok((name, id)) = parser::device(&line) {
-            // We should always have a current vendor; failure here indicates a malformed input.
-            let curr_vendor = curr_vendor.as_mut().unwrap();
-            curr_vendor.devices.push(CgDevice {
-                id,
-                name: name.into(),
-                interfaces: vec![],
-            });
-            curr_device_id = id;
-        } else if let Ok((name, id)) = parser::interface(&line) {
-            // We should always have a current vendor; failure here indicates a malformed input.
-            // Similarly, our current vendor should always have a device corresponding
-            // to the current device id.
-            let curr_vendor = curr_vendor.as_mut().unwrap();
-            let curr_device = curr_vendor
-                .devices
-                .iter_mut()
-                .find(|d| d.id == curr_device_id)
-                .unwrap();
+            if let Some(next_state) = parser_state.next_from_header(&line, &mut output) {
+                parser_state = next_state;
+            }
 
-            curr_device.interfaces.push(CgInterface {
-                id,
-                name: name.into(),
-            });
-        } else {
-            // TODO: Lots of other things that could be parsed out:
-            // Language, dialect, country code, HID types, ...
-            break;
+            parser_state.process(&line);
         }
     }
-    if let Some(vendor) = curr_vendor.take() {
-        emit_vendor(&mut map, &vendor);
-    }
 
-    emit_epilogue(&mut output, map);
+    // last call
+    parser_state.finalize(&mut output);
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/usb.ids");
@@ -142,20 +589,76 @@ mod parser {
         let id = id(2, u8::from_str_radix);
         delimited(tag("\t\t"), id, tag("  "))(input)
     }
-}
 
-fn emit_prologue(output: &mut impl Write) -> VMap {
-    writeln!(output, "static USB_IDS: phf::Map<u16, Vendor> = ").unwrap();
+    pub fn class(input: &str) -> IResult<&str, u8> {
+        let id = id(2, u8::from_str_radix);
+        delimited(tag("C "), id, tag("  "))(input)
+    }
 
-    Map::new()
-}
+    pub fn sub_class(input: &str) -> IResult<&str, u8> {
+        let id = id(2, u8::from_str_radix);
+        delimited(tab, id, tag("  "))(input)
+    }
 
-fn emit_vendor(map: &mut VMap, vendor: &CgVendor) {
-    map.entry(vendor.id, &quote!(#vendor).to_string());
-}
+    pub fn protocol(input: &str) -> IResult<&str, u8> {
+        let id = id(2, u8::from_str_radix);
+        delimited(tag("\t\t"), id, tag("  "))(input)
+    }
 
-fn emit_epilogue(output: &mut impl Write, map: VMap) {
-    writeln!(output, "{};", map.build()).unwrap();
+    pub fn audio_terminal_type(input: &str) -> IResult<&str, u16> {
+        let id = id(4, u16::from_str_radix);
+        delimited(tag("AT "), id, tag("  "))(input)
+    }
+
+    pub fn hid_type(input: &str) -> IResult<&str, u8> {
+        let id = id(2, u8::from_str_radix);
+        delimited(tag("HID "), id, tag("  "))(input)
+    }
+
+    pub fn hid_item_type(input: &str) -> IResult<&str, u8> {
+        let id = id(2, u8::from_str_radix);
+        delimited(tag("R "), id, tag("  "))(input)
+    }
+
+    pub fn bias_type(input: &str) -> IResult<&str, u8> {
+        let id = id(1, u8::from_str_radix);
+        delimited(tag("BIAS "), id, tag("  "))(input)
+    }
+
+    pub fn phy_type(input: &str) -> IResult<&str, u8> {
+        let id = id(2, u8::from_str_radix);
+        delimited(tag("PHY "), id, tag("  "))(input)
+    }
+
+    pub fn hut_type(input: &str) -> IResult<&str, u8> {
+        let id = id(2, u8::from_str_radix);
+        delimited(tag("HUT "), id, tag("  "))(input)
+    }
+
+    pub fn hid_usage_name(input: &str) -> IResult<&str, u16> {
+        let id = id(3, u16::from_str_radix);
+        delimited(tab, id, tag("  "))(input)
+    }
+
+    pub fn language(input: &str) -> IResult<&str, u16> {
+        let id = id(4, u16::from_str_radix);
+        delimited(tag("L "), id, tag("  "))(input)
+    }
+
+    pub fn dialect(input: &str) -> IResult<&str, u8> {
+        let id = id(2, u8::from_str_radix);
+        delimited(tab, id, tag("  "))(input)
+    }
+
+    pub fn country_code(input: &str) -> IResult<&str, u8> {
+        let id = id(2, u8::from_str_radix);
+        delimited(tag("HCC "), id, tag("  "))(input)
+    }
+
+    pub fn terminal_type(input: &str) -> IResult<&str, u16> {
+        let id = id(4, u16::from_str_radix);
+        delimited(tag("VT "), id, tag("  "))(input)
+    }
 }
 
 impl quote::ToTokens for CgVendor {
@@ -177,11 +680,39 @@ impl quote::ToTokens for CgVendor {
     }
 }
 
-impl quote::ToTokens for CgInterface {
+impl quote::ToTokens for CgClass {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let CgInterface { id, name } = self;
+        let CgClass {
+            id: class_id,
+            name,
+            sub_classes,
+        } = self;
+
+        let sub_classes = sub_classes.iter().map(|CgSubClass { id, name, children }| {
+            quote!{
+                SubClass { class_id: #class_id, id: #id, name: #name, protocols: &[#(#children),*] }
+            }
+        });
         tokens.extend(quote! {
-            Interface { id: #id, name: #name }
+            Class { id: #class_id, name: #name, sub_classes: &[#(#sub_classes),*] }
+        });
+    }
+}
+
+impl<T: quote::ToTokens, C: quote::ToTokens> quote::ToTokens for CgParentType<T, C> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let CgParentType { id, name, children } = self;
+        tokens.extend(quote! {
+            UsbIdWithChildren { id: #id, name: #name, children: &[#(#children),*] }
+        });
+    }
+}
+
+impl<T: quote::ToTokens> quote::ToTokens for CgType<T> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let CgType { id, name } = self;
+        tokens.extend(quote! {
+            UsbId { id: #id, name: #name }
         });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,17 @@
 
 #![warn(missing_docs)]
 
-// Codegen: introduces USB_IDS, a phf::Map<u16, Vendor>.
 include!(concat!(env!("OUT_DIR"), "/usb_ids.cg.rs"));
+
+const AT_ID: u8 = 1;
+const HID_ID: u8 = 2;
+const HID_TYPE_ID: u8 = 3;
+const HID_USAGE_ID: u8 = 4;
+const BIAS_ID: u8 = 5;
+const PHY_ID: u8 = 6;
+const DIALECT_ID: u8 = 7;
+const HCC_ID: u8 = 8;
+const VT_ID: u8 = 9;
 
 /// An abstraction for iterating over all vendors in the USB database.
 pub struct Vendors;
@@ -33,6 +42,15 @@ impl Vendors {
     /// Returns an iterator over all vendors in the USB database.
     pub fn iter() -> impl Iterator<Item = &'static Vendor> {
         USB_IDS.values()
+    }
+}
+
+/// An abstraction for iterating over all classes in the USB database.
+pub struct Classes;
+impl Classes {
+    /// Returns an iterator over all classes in the USB database.
+    pub fn iter() -> impl Iterator<Item = &'static Class> {
+        USB_CLASSES.values()
     }
 }
 
@@ -146,8 +164,6 @@ impl Interface {
 
 /// A convenience trait for retrieving a top-level entity (like a [`Vendor`]) from the USB
 /// database by its unique ID.
-// NOTE(ww): This trait will be generally useful once we support other top-level
-// entities in `usb.ids` (like language, country code, HID codes, etc).
 pub trait FromId<T> {
     /// Returns the entity corresponding to `id`, or `None` if none exists.
     fn from_id(id: T) -> Option<&'static Self>;
@@ -158,6 +174,270 @@ impl FromId<u16> for Vendor {
         USB_IDS.get(&id)
     }
 }
+
+impl FromId<u8> for Class {
+    fn from_id(id: u8) -> Option<&'static Self> {
+        USB_CLASSES.get(&id)
+    }
+}
+
+impl FromId<u16> for AudioTerminal {
+    fn from_id(id: u16) -> Option<&'static Self> {
+        USB_AUDIO_TERMINALS.get(&id)
+    }
+}
+
+impl FromId<u8> for Hid {
+    fn from_id(id: u8) -> Option<&'static Self> {
+        USB_HID_IDS.get(&id)
+    }
+}
+
+impl FromId<u8> for HidItemType {
+    fn from_id(id: u8) -> Option<&'static Self> {
+        USB_HID_R_TYPES.get(&id)
+    }
+}
+
+impl FromId<u8> for HidUsagePage {
+    fn from_id(id: u8) -> Option<&'static Self> {
+        USB_HUTS.get(&id)
+    }
+}
+
+impl FromId<u8> for Bias {
+    fn from_id(id: u8) -> Option<&'static Self> {
+        USB_BIASES.get(&id)
+    }
+}
+
+impl FromId<u8> for Phy {
+    fn from_id(id: u8) -> Option<&'static Self> {
+        USB_PHYS.get(&id)
+    }
+}
+
+impl FromId<u16> for Language {
+    fn from_id(id: u16) -> Option<&'static Self> {
+        USB_LANGS.get(&id)
+    }
+}
+
+impl FromId<u8> for HidCountryCode {
+    fn from_id(id: u8) -> Option<&'static Self> {
+        USB_HID_CCS.get(&id)
+    }
+}
+
+impl FromId<u16> for VideoTerminal {
+    fn from_id(id: u16) -> Option<&'static Self> {
+        USB_VIDEO_TERMINALS.get(&id)
+    }
+}
+
+/// Represents a USB device class in the USB database.
+///
+/// Every device class has a class ID, a pretty name, and a
+/// list of associated [`SubClass`]s.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Class {
+    id: u8,
+    name: &'static str,
+    sub_classes: &'static [SubClass],
+}
+
+impl Class {
+    /// Returns the class's ID.
+    pub fn id(&self) -> u8 {
+        self.id
+    }
+
+    /// Returns the class's name.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns an iterator over the class's subclasses.
+    pub fn sub_classes(&self) -> impl Iterator<Item = &'static SubClass> {
+        self.sub_classes.iter()
+    }
+}
+
+/// Represents a class subclass in the USB database.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SubClass {
+    class_id: u8,
+    id: u8,
+    name: &'static str,
+    protocols: &'static [Protocol],
+}
+
+impl SubClass {
+    /// Returns the [`SubClass`] corresponding to the given class and subclass IDs,
+    /// or `None` if no such subclass exists in the DB.
+    pub fn from_cid_scid(class_id: u8, id: u8) -> Option<&'static Self> {
+        let class = Class::from_id(class_id);
+
+        class.and_then(|c| c.sub_classes().find(|s| s.id == id))
+    }
+
+    /// Returns the [`Class`] that this subclass belongs to.
+    ///
+    /// Looking up a class by subclass is cheap (`O(1)`).
+    pub fn class(&self) -> &'static Class {
+        USB_CLASSES.get(&self.class_id).unwrap()
+    }
+
+    /// Returns a tuple of (class id, subclass id) for this subclass.
+    ///
+    /// This is convenient for interactions with other USB libraries.
+    pub fn as_cid_scid(&self) -> (u8, u8) {
+        (self.class_id, self.id)
+    }
+
+    /// Returns the subclass' ID.
+    pub fn id(&self) -> u8 {
+        self.id
+    }
+
+    /// Returns the subclass' name.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns an iterator over the subclasses's protocols.
+    ///
+    /// **NOTE**: The USB database nor USB-IF includes protocol information for
+    /// all subclassess. This list is not authoritative.
+    pub fn protocols(&self) -> impl Iterator<Item = &'static Protocol> {
+        self.protocols.iter()
+    }
+}
+
+const PROTOCOL_ID: u8 = 0;
+/// Represents a subclass protocol in the USB database.
+pub type Protocol = UsbId<PROTOCOL_ID, u8>;
+
+impl Protocol {
+    /// Returns the [`Protocol`] corresponding to the given class, subclass, and protocol IDs,
+    /// or `None` if no such protocol exists in the DB.
+    pub fn from_cid_scid_pid(class_id: u8, subclass_id: u8, id: u8) -> Option<&'static Self> {
+        let subclass = SubClass::from_cid_scid(class_id, subclass_id);
+
+        subclass.and_then(|s| s.protocols().find(|p| p.id == id))
+    }
+}
+
+/// Represents a generic USB ID in the USB database.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UsbId<const ID: u8, T> {
+    id: T,
+    name: &'static str,
+}
+
+impl<const ID: u8, T: Copy> UsbId<ID, T> {
+    /// Returns the type's ID.
+    pub fn id(&self) -> T {
+        self.id
+    }
+
+    /// Returns the type's name.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+/// Represents a generic USB ID in the USB database with children IDs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UsbIdWithChildren<T: Copy, C: 'static> {
+    id: T,
+    name: &'static str,
+    children: &'static [C],
+}
+
+impl<T: Copy, C: 'static> UsbIdWithChildren<T, C> {
+    /// Returns the type's ID.
+    pub fn id(&self) -> T {
+        self.id
+    }
+
+    /// Returns the type's name.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns an iterator over the type's children.
+    fn children(&self) -> impl Iterator<Item = &'static C> {
+        self.children.iter()
+    }
+}
+
+/// Represents an audio terminal in the USB database.
+pub type AudioTerminal = UsbId<AT_ID, u16>;
+
+/// Represents a HID descriptor type in the USB database.
+pub type Hid = UsbId<HID_ID, u8>;
+
+/// Represents a HID descriptor item type in the USB database.
+pub type HidItemType = UsbId<HID_TYPE_ID, u8>;
+
+/// Represents a HID usage page in the USB database.
+pub type HidUsagePage = UsbIdWithChildren<u8, HidUsage>;
+
+impl HidUsagePage {
+    /// Returns an iterator over the page's usages.
+    pub fn usages(&self) -> impl Iterator<Item = &'static HidUsage> {
+        self.children()
+    }
+}
+
+/// Represents a HID usage in the USB database.
+pub type HidUsage = UsbId<HID_USAGE_ID, u16>;
+
+impl HidUsage {
+    /// Returns the [`HidUsage`] corresponding to the given usage page and usage ID,
+    /// or `None` if no such usage exists in the DB.
+    pub fn from_pageid_uid(page_id: u8, id: u16) -> Option<&'static Self> {
+        let page = HidUsagePage::from_id(page_id)?;
+
+        page.children().find(|u| u.id() == id)
+    }
+}
+
+/// Physical descriptor bias types
+pub type Bias = UsbId<BIAS_ID, u8>;
+
+/// Physical descriptor item types
+pub type Phy = UsbId<PHY_ID, u8>;
+
+/// Represents a language in the USB database.
+pub type Language = UsbIdWithChildren<u16, Dialect>;
+
+impl Language {
+    /// Returns an iterator over the language's dialects.
+    pub fn dialects(&self) -> impl Iterator<Item = &'static Dialect> {
+        self.children()
+    }
+}
+
+/// Represents a language dialect in the USB database.
+pub type Dialect = UsbId<DIALECT_ID, u8>;
+
+impl Dialect {
+    /// Returns the [`Dialect`] corresponding to the given language and dialect IDs,
+    /// or `None` if no such dialect exists in the DB.
+    pub fn from_lid_did(language_id: u16, id: u8) -> Option<&'static Self> {
+        let language = Language::from_id(language_id)?;
+
+        language.children().find(|d| d.id() == id)
+    }
+}
+
+/// Represents a HID descriptor country code in the USB database.
+pub type HidCountryCode = UsbId<HCC_ID, u8>;
+
+/// Represents a video class terminal type in the USB database.
+pub type VideoTerminal = UsbId<VT_ID, u16>;
 
 #[cfg(test)]
 mod tests {
@@ -195,5 +475,131 @@ mod tests {
         let device2 = Device::from_vid_pid(vid, pid).unwrap();
 
         assert_eq!(device, device2);
+
+        let last_device = Device::from_vid_pid(0xffee, 0x0100).unwrap();
+        assert_eq!(last_device.name(), "Card Reader Controller RTS5101/RTS5111/RTS5116");
+    }
+
+    #[test]
+    fn test_class_from_id() {
+        let class = Class::from_id(0x03).unwrap();
+
+        assert_eq!(class.name(), "Human Interface Device");
+        assert_eq!(class.id(), 0x03);
+    }
+
+    #[test]
+    fn test_subclass_from_cid_scid() {
+        let subclass = SubClass::from_cid_scid(0x03, 0x01).unwrap();
+
+        assert_eq!(subclass.name(), "Boot Interface Subclass");
+        assert_eq!(subclass.id(), 0x01);
+    }
+
+    #[test]
+    fn test_protocol_from_cid_scid_pid() {
+        let protocol = Protocol::from_cid_scid_pid(0x03, 0x01, 0x01).unwrap();
+
+        assert_eq!(protocol.name(), "Keyboard");
+        assert_eq!(protocol.id(), 0x01);
+
+        let protocol = Protocol::from_cid_scid_pid(0x07, 0x01, 0x03).unwrap();
+
+        assert_eq!(protocol.name(), "IEEE 1284.4 compatible bidirectional");
+        assert_eq!(protocol.id(), 0x03);
+
+        let protocol = Protocol::from_cid_scid_pid(0xff, 0xff, 0xff).unwrap();
+
+        // check last entry for parsing
+        assert_eq!(protocol.name(), "Vendor Specific Protocol");
+        assert_eq!(protocol.id(), 0xff);
+    }
+
+    #[test]
+    fn test_at_from_id() {
+        let at = AudioTerminal::from_id(0x0713).unwrap();
+
+        assert_eq!(at.name(), "Synthesizer");
+        assert_eq!(at.id(), 0x0713);
+    }
+
+    #[test]
+    fn test_hid_from_id() {
+        let hid = Hid::from_id(0x23).unwrap();
+
+        assert_eq!(hid.name(), "Physical");
+        assert_eq!(hid.id(), 0x23);
+    }
+
+    #[test]
+    fn test_hid_type_from_id() {
+        let hid_type = HidItemType::from_id(0xc0).unwrap();
+
+        assert_eq!(hid_type.name(), "End Collection");
+        assert_eq!(hid_type.id(), 0xc0);
+    }
+
+    #[test]
+    fn test_bias_from_id() {
+        let bias = Bias::from_id(0x04).unwrap();
+
+        assert_eq!(bias.name(), "Either Hand");
+        assert_eq!(bias.id(), 0x04);
+    }
+
+    #[test]
+    fn test_phy_from_id() {
+        let phy = Phy::from_id(0x27).unwrap();
+
+        assert_eq!(phy.name(), "Cheek");
+        assert_eq!(phy.id(), 0x27);
+    }
+
+    #[test]
+    fn test_hid_usages_from_id() {
+        let hid_usage_page = HidUsagePage::from_id(0x0d).unwrap();
+
+        assert_eq!(hid_usage_page.name(), "Digitizer");
+        assert_eq!(hid_usage_page.id(), 0x0d);
+
+        let hid_usage = HidUsage::from_pageid_uid(0x0d, 0x01).unwrap();
+
+        assert_eq!(hid_usage.name(), "Digitizer");
+        assert_eq!(hid_usage.id(), 0x01);
+    }
+
+    #[test]
+    fn test_language_from_id() {
+        let language = Language::from_id(0x0007).unwrap();
+
+        assert_eq!(language.name(), "German");
+        assert_eq!(language.id(), 0x0007);
+
+        let dialect = language.dialects().find(|d| d.id() == 0x02).unwrap();
+
+        assert_eq!(dialect.name(), "Swiss");
+        assert_eq!(dialect.id(), 0x02);
+    }
+
+    #[test]
+    fn test_hid_country_code_from_id() {
+        let hid_country_code = HidCountryCode::from_id(0x29).unwrap();
+
+        assert_eq!(hid_country_code.name(), "Switzerland");
+        assert_eq!(hid_country_code.id(), 0x29);
+
+        let hid_country_code = HidCountryCode::from_id(0x00).unwrap();
+        assert_eq!(hid_country_code.name(), "Not supported");
+    }
+
+    #[test]
+    fn test_video_terminal_from_id() {
+        let video_terminal = VideoTerminal::from_id(0x0100).unwrap();
+
+        assert_eq!(video_terminal.name(), "USB Vendor Specific");
+        assert_eq!(video_terminal.id(), 0x0100);
+
+        let video_terminal = VideoTerminal::from_id(0x0403).unwrap();
+        assert_eq!(video_terminal.name(), "Component Video");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,7 +382,7 @@ const DIALECT_TAG: u8 = 7;
 const HCC_TAG: u8 = 8;
 const VT_TAG: u8 = 9;
 
-/// Represents a subclass protocol in the USB database. 
+/// Represents a subclass protocol in the USB database.
 ///
 /// Protocols are part of the USB class code triplet (base class, subclass,
 /// protocol), contained within a [`SubClass`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,22 @@
 //! }
 //! ```
 //!
+//! Iterating over all known classes:
+//!
+//! ```rust
+//! use usb_ids::Classes;
+//!
+//! for class in Classes::iter() {
+//!     println!("class: {}", class.name());
+//!     for subclass in class.sub_classes() {
+//!         println!("\tsubclass: {}", subclass.name());
+//!         for protocol in subclass.protocols() {
+//!            println!("\t\tprotocol: {}", protocol.name());
+//!         }
+//!     }
+//! }
+//! ```
+//!
 //! See the individual documentation for each structure for more details.
 //!
 
@@ -26,15 +42,53 @@
 
 include!(concat!(env!("OUT_DIR"), "/usb_ids.cg.rs"));
 
-const AT_ID: u8 = 1;
-const HID_ID: u8 = 2;
-const HID_TYPE_ID: u8 = 3;
-const HID_USAGE_ID: u8 = 4;
-const BIAS_ID: u8 = 5;
-const PHY_ID: u8 = 6;
-const DIALECT_ID: u8 = 7;
-const HCC_ID: u8 = 8;
-const VT_ID: u8 = 9;
+/// Represents a generic USB ID in the USB database.
+///
+/// Not designed to be used directly; use one of the type aliases instead.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UsbId<const ID: u8, T> {
+    id: T,
+    name: &'static str,
+}
+
+impl<const ID: u8, T: Copy> UsbId<ID, T> {
+    /// Returns the type's ID.
+    pub fn id(&self) -> T {
+        self.id
+    }
+
+    /// Returns the type's name.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+/// Represents a generic USB ID in the USB database with children IDs.
+///
+/// Not designed to be used directly; use one of the type aliases instead.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UsbIdWithChildren<T: Copy, C: 'static> {
+    id: T,
+    name: &'static str,
+    children: &'static [C],
+}
+
+impl<T: Copy, C: 'static> UsbIdWithChildren<T, C> {
+    /// Returns the type's ID.
+    pub fn id(&self) -> T {
+        self.id
+    }
+
+    /// Returns the type's name.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns an iterator over the type's children.
+    fn children(&self) -> impl Iterator<Item = &'static C> {
+        self.children.iter()
+    }
+}
 
 /// An abstraction for iterating over all vendors in the USB database.
 pub struct Vendors;
@@ -51,6 +105,45 @@ impl Classes {
     /// Returns an iterator over all classes in the USB database.
     pub fn iter() -> impl Iterator<Item = &'static Class> {
         USB_CLASSES.values()
+    }
+}
+
+/// An abstraction for iterating over all languages in the USB database.
+///
+/// ```
+/// use usb_ids::Languages;
+/// for language in Languages::iter() {
+///    println!("language: {}", language.name());
+///    for dialect in language.dialects() {
+///         println!("\tdialect: {}", dialect.name());
+///    }
+/// }
+/// ```
+pub struct Languages;
+impl Languages {
+    /// Returns an iterator over all languages in the USB database.
+    pub fn iter() -> impl Iterator<Item = &'static Language> {
+        USB_LANGS.values()
+    }
+}
+
+/// An abstraction for iterating over all HID usage pages in the USB database.
+///
+/// ```
+/// use usb_ids::HidUsagePages;
+///
+/// for page in HidUsagePages::iter() {
+///     println!("page: {}", page.name());
+///     for usage in page.usages() {
+///         println!("\tusage: {}", usage.name());
+///     }
+/// }
+/// ```
+pub struct HidUsagePages;
+impl HidUsagePages {
+    /// Returns an iterator over all HID usage pages in the USB database.
+    pub fn iter() -> impl Iterator<Item = &'static HidUsagePage> {
+        USB_HUTS.values()
     }
 }
 
@@ -76,7 +169,7 @@ impl Vendor {
         self.name
     }
 
-    /// Returns an iterator over the vendor's devices.
+    /// Returns an iterator over the vendor's [`Device`]s.
     pub fn devices(&self) -> impl Iterator<Item = &'static Device> {
         self.devices.iter()
     }
@@ -97,6 +190,12 @@ pub struct Device {
 impl Device {
     /// Returns the [`Device`] corresponding to the given vendor and product IDs,
     /// or `None` if no such device exists in the DB.
+    ///
+    /// ```
+    /// use usb_ids::Device;
+    /// let device = Device::from_vid_pid(0x1d6b, 0x0003).unwrap();
+    /// assert_eq!(device.name(), "3.0 root hub");
+    /// ```
     pub fn from_vid_pid(vid: u16, pid: u16) -> Option<&'static Device> {
         let vendor = Vendor::from_id(vid);
 
@@ -127,7 +226,7 @@ impl Device {
         self.name
     }
 
-    /// Returns an iterator over the device's interfaces.
+    /// Returns an iterator over the device's [`Interface`]s.
     ///
     /// **NOTE**: The USB database does not include interface information for
     /// most devices. This list is not authoritative.
@@ -162,8 +261,323 @@ impl Interface {
     }
 }
 
+/// Represents a USB device class in the USB database.
+///
+/// Every device class has a class ID, a pretty name, and a
+/// list of associated [`SubClass`]s.
+///
+/// ```
+/// use usb_ids::{Class, Classes, FromId};
+/// let class = Class::from_id(0x03).unwrap();
+/// assert_eq!(class.name(), "Human Interface Device");
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Class {
+    id: u8,
+    name: &'static str,
+    sub_classes: &'static [SubClass],
+}
+
+impl Class {
+    /// Returns the class's ID.
+    pub fn id(&self) -> u8 {
+        self.id
+    }
+
+    /// Returns the class's name.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns an iterator over the class's [`SubClass`]s.
+    pub fn sub_classes(&self) -> impl Iterator<Item = &'static SubClass> {
+        self.sub_classes.iter()
+    }
+}
+
+/// Represents a class subclass in the USB database. Subclasses are part of the
+/// USB class code triplet (base class, subclass, protocol).
+///
+/// Contained within a [`Class`] and may contain a list of associated
+/// [`Protocol`]s.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SubClass {
+    class_id: u8,
+    id: u8,
+    name: &'static str,
+    protocols: &'static [Protocol],
+}
+
+impl SubClass {
+    /// Returns the [`SubClass`] corresponding to the given class and subclass IDs,
+    /// or `None` if no such subclass exists in the DB.
+    ///
+    /// ```
+    /// use usb_ids::SubClass;
+    /// let subclass = SubClass::from_cid_scid(0x02, 0x03).unwrap();
+    /// assert_eq!(subclass.name(), "Telephone");
+    ///
+    /// assert!(SubClass::from_cid_scid(0x3c, 0x02).is_none());
+    /// ```
+    pub fn from_cid_scid(class_id: u8, id: u8) -> Option<&'static Self> {
+        let class = Class::from_id(class_id);
+
+        class.and_then(|c| c.sub_classes().find(|s| s.id == id))
+    }
+
+    /// Returns the [`Class`] that this subclass belongs to.
+    ///
+    /// Looking up a class by subclass is cheap (`O(1)`).
+    ///
+    /// ```
+    /// use usb_ids::SubClass;
+    /// let subclass = SubClass::from_cid_scid(0x02, 0x03).unwrap();
+    /// let class = subclass.class();
+    /// assert_eq!(class.id(), 0x02);
+    /// ```
+    pub fn class(&self) -> &'static Class {
+        USB_CLASSES.get(&self.class_id).unwrap()
+    }
+
+    /// Returns a tuple of (class id, subclass id) for this subclass.
+    ///
+    /// This is convenient for interactions with other USB libraries.
+    pub fn as_cid_scid(&self) -> (u8, u8) {
+        (self.class_id, self.id)
+    }
+
+    /// Returns the subclass' ID.
+    pub fn id(&self) -> u8 {
+        self.id
+    }
+
+    /// Returns the subclass' name.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns an iterator over the subclasses's [`Protocol`]s.
+    ///
+    /// **NOTE**: The USB database nor USB-IF includes protocol information for
+    /// all subclassess. This list is not authoritative.
+    pub fn protocols(&self) -> impl Iterator<Item = &'static Protocol> {
+        self.protocols.iter()
+    }
+}
+
+/// These are tags for UsbId type aliases to make them unique and allow a
+/// [`FromId`] for each alias. The values are arbitrary but must be unique.
+///
+/// [`std::marker::PhantomData`] would be nicer but was unable to figure out a
+/// generic way to add the _tag: PhantomData in the ToToken trait
+/// implementation within build.rs
+const PROTOCOL_TAG: u8 = 0;
+const AT_TAG: u8 = 1;
+const HID_TAG: u8 = 2;
+const HID_TYPE_TAG: u8 = 3;
+const HID_USAGE_TAG: u8 = 4;
+const BIAS_TAG: u8 = 5;
+const PHY_TAG: u8 = 6;
+const DIALECT_TAG: u8 = 7;
+const HCC_TAG: u8 = 8;
+const VT_TAG: u8 = 9;
+
+/// Represents a subclass protocol in the USB database. 
+///
+/// Protocols are part of the USB class code triplet (base class, subclass,
+/// protocol), contained within a [`SubClass`].
+pub type Protocol = UsbId<PROTOCOL_TAG, u8>;
+
+impl Protocol {
+    /// Returns the [`Protocol`] corresponding to the given class, subclass, and protocol IDs,
+    /// or `None` if no such protocol exists in the DB.
+    ///
+    /// ```
+    /// use usb_ids::Protocol;
+    /// let protocol = Protocol::from_cid_scid_pid(0x02, 0x02, 0x05).unwrap();
+    /// assert_eq!(protocol.name(), "AT-commands (3G)");
+    /// ```
+    pub fn from_cid_scid_pid(class_id: u8, subclass_id: u8, id: u8) -> Option<&'static Self> {
+        let subclass = SubClass::from_cid_scid(class_id, subclass_id);
+
+        subclass.and_then(|s| s.protocols().find(|p| p.id == id))
+    }
+}
+
+/// Represents an audio terminal type in the USB database.
+///
+/// ```
+/// use usb_ids::{AudioTerminal, FromId};
+/// let audio_terminal = AudioTerminal::from_id(0x0201).unwrap();
+/// assert_eq!(audio_terminal.name(), "Microphone");
+/// ```
+pub type AudioTerminal = UsbId<AT_TAG, u16>;
+
+/// Represents a HID descriptor type in the USB database.
+///
+/// ```
+/// use usb_ids::{Hid, FromId};
+/// let hid = Hid::from_id(0x22).unwrap();
+/// assert_eq!(hid.name(), "Report");
+/// ```
+pub type Hid = UsbId<HID_TAG, u8>;
+
+/// Represents a HID descriptor item type in the USB database.
+///
+/// ```
+/// use usb_ids::{HidItemType, FromId};
+/// let hid_item_type = HidItemType::from_id(0xb4).unwrap();
+/// assert_eq!(hid_item_type.name(), "Pop");
+/// ```
+pub type HidItemType = UsbId<HID_TYPE_TAG, u8>;
+
+/// Represents a HID usage page in the USB database.
+///
+/// Every HID usage page has a usage page ID, a pretty name, and a list of
+/// associated [`HidUsage`]s.
+///
+/// ```
+/// use usb_ids::{HidUsagePage, FromId};
+/// let hid_usage_page = HidUsagePage::from_id(0x01).unwrap();
+/// assert_eq!(hid_usage_page.name(), "Generic Desktop Controls");
+///
+/// for usage in hid_usage_page.usages() {
+///   println!("usage: {}", usage.name());
+/// }
+/// ```
+pub type HidUsagePage = UsbIdWithChildren<u8, HidUsage>;
+
+impl HidUsagePage {
+    /// Returns an iterator over the page's [`HidUsage`]s.
+    pub fn usages(&self) -> impl Iterator<Item = &'static HidUsage> {
+        self.children()
+    }
+}
+
+/// Represents a HID usage type in the USB database.
+///
+/// ```
+/// use usb_ids::{HidUsage, HidUsagePage, FromId};
+///
+/// let hid_usage_page = HidUsagePage::from_id(0x01).unwrap();
+/// for usage in hid_usage_page.usages() {
+///    println!("usage: {}", usage.name());
+/// }
+/// ```
+pub type HidUsage = UsbId<HID_USAGE_TAG, u16>;
+
+impl HidUsage {
+    /// Returns the [`HidUsage`] corresponding to the given usage page and usage ID,
+    /// or `None` if no such usage exists in the DB.
+    ///
+    /// ```
+    /// use usb_ids::HidUsage;
+    /// let hid_usage = HidUsage::from_pageid_uid(0x01, 0x002).unwrap();
+    /// assert_eq!(hid_usage.name(), "Mouse");
+    /// ```
+    pub fn from_pageid_uid(page_id: u8, id: u16) -> Option<&'static Self> {
+        let page = HidUsagePage::from_id(page_id)?;
+
+        page.children().find(|u| u.id() == id)
+    }
+}
+
+/// Represents physical descriptor bias type in the USB database.
+///
+/// ```
+/// use usb_ids::{Bias, FromId};
+/// let bias = Bias::from_id(0x02).unwrap();
+/// assert_eq!(bias.name(), "Left Hand");
+/// ```
+pub type Bias = UsbId<BIAS_TAG, u8>;
+
+/// Represents physical descriptor item type in the USB database.
+///
+/// ```
+/// use usb_ids::{Phy, FromId};
+/// let phy = Phy::from_id(0x25).unwrap();
+/// assert_eq!(phy.name(), "Fifth Toe");
+/// ```
+pub type Phy = UsbId<PHY_TAG, u8>;
+
+/// Represents a language type in the USB database.
+///
+/// Languages have a language ID, a pretty name, and a list of associated
+/// [`Dialect`]s.
+///
+/// ```
+/// use usb_ids::{Language, FromId};
+/// let language = Language::from_id(0x000c).unwrap();
+/// assert_eq!(language.name(), "French");
+///
+/// for dialect in language.dialects() {
+///   println!("dialect: {}", dialect.name());
+/// }
+/// ```
+pub type Language = UsbIdWithChildren<u16, Dialect>;
+
+impl Language {
+    /// Returns an iterator over the language's [`Dialect`]s.
+    pub fn dialects(&self) -> impl Iterator<Item = &'static Dialect> {
+        self.children()
+    }
+}
+
+/// Represents a language dialect in the USB database.
+///
+/// ```
+/// use usb_ids::{Dialect, Language, FromId};
+/// let lang = Language::from_id(0x0007).unwrap();
+///
+/// println!("language: {}", lang.name());
+/// for dialect in lang.dialects() {
+///    println!("\tdialect: {}", dialect.name());
+/// }
+/// ```
+pub type Dialect = UsbId<DIALECT_TAG, u8>;
+
+impl Dialect {
+    /// Returns the [`Dialect`] corresponding to the given language and dialect IDs,
+    /// or `None` if no such dialect exists in the DB.
+    ///
+    /// ```
+    /// use usb_ids::Dialect;
+    /// let dialect = Dialect::from_lid_did(0x0007, 0x02).unwrap();
+    /// assert_eq!(dialect.name(), "Swiss");
+    /// ```
+    pub fn from_lid_did(language_id: u16, id: u8) -> Option<&'static Self> {
+        let language = Language::from_id(language_id)?;
+
+        language.children().find(|d| d.id() == id)
+    }
+}
+
+/// Represents a HID descriptor country code in the USB database.
+///
+/// ```
+/// use usb_ids::{HidCountryCode, FromId};
+/// let hid_country_code = HidCountryCode::from_id(0x29).unwrap();
+/// assert_eq!(hid_country_code.name(), "Switzerland");
+/// ```
+pub type HidCountryCode = UsbId<HCC_TAG, u8>;
+
+/// Represents a video class terminal type in the USB database.
+///
+/// ```
+/// use usb_ids::{VideoTerminal, FromId};
+/// let video_terminal = VideoTerminal::from_id(0x0101).unwrap();
+/// assert_eq!(video_terminal.name(), "USB Streaming");
+/// ```
+pub type VideoTerminal = UsbId<VT_TAG, u16>;
+
 /// A convenience trait for retrieving a top-level entity (like a [`Vendor`]) from the USB
 /// database by its unique ID.
+///
+/// ```
+/// use usb_ids::{FromId, Vendor};
+/// let vendor = Vendor::from_id(0x1d6b).unwrap();
+/// assert_eq!(vendor.name(), "Linux Foundation");
+/// ```
 pub trait FromId<T> {
     /// Returns the entity corresponding to `id`, or `None` if none exists.
     fn from_id(id: T) -> Option<&'static Self>;
@@ -235,210 +649,6 @@ impl FromId<u16> for VideoTerminal {
     }
 }
 
-/// Represents a USB device class in the USB database.
-///
-/// Every device class has a class ID, a pretty name, and a
-/// list of associated [`SubClass`]s.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Class {
-    id: u8,
-    name: &'static str,
-    sub_classes: &'static [SubClass],
-}
-
-impl Class {
-    /// Returns the class's ID.
-    pub fn id(&self) -> u8 {
-        self.id
-    }
-
-    /// Returns the class's name.
-    pub fn name(&self) -> &'static str {
-        self.name
-    }
-
-    /// Returns an iterator over the class's subclasses.
-    pub fn sub_classes(&self) -> impl Iterator<Item = &'static SubClass> {
-        self.sub_classes.iter()
-    }
-}
-
-/// Represents a class subclass in the USB database.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct SubClass {
-    class_id: u8,
-    id: u8,
-    name: &'static str,
-    protocols: &'static [Protocol],
-}
-
-impl SubClass {
-    /// Returns the [`SubClass`] corresponding to the given class and subclass IDs,
-    /// or `None` if no such subclass exists in the DB.
-    pub fn from_cid_scid(class_id: u8, id: u8) -> Option<&'static Self> {
-        let class = Class::from_id(class_id);
-
-        class.and_then(|c| c.sub_classes().find(|s| s.id == id))
-    }
-
-    /// Returns the [`Class`] that this subclass belongs to.
-    ///
-    /// Looking up a class by subclass is cheap (`O(1)`).
-    pub fn class(&self) -> &'static Class {
-        USB_CLASSES.get(&self.class_id).unwrap()
-    }
-
-    /// Returns a tuple of (class id, subclass id) for this subclass.
-    ///
-    /// This is convenient for interactions with other USB libraries.
-    pub fn as_cid_scid(&self) -> (u8, u8) {
-        (self.class_id, self.id)
-    }
-
-    /// Returns the subclass' ID.
-    pub fn id(&self) -> u8 {
-        self.id
-    }
-
-    /// Returns the subclass' name.
-    pub fn name(&self) -> &'static str {
-        self.name
-    }
-
-    /// Returns an iterator over the subclasses's protocols.
-    ///
-    /// **NOTE**: The USB database nor USB-IF includes protocol information for
-    /// all subclassess. This list is not authoritative.
-    pub fn protocols(&self) -> impl Iterator<Item = &'static Protocol> {
-        self.protocols.iter()
-    }
-}
-
-const PROTOCOL_ID: u8 = 0;
-/// Represents a subclass protocol in the USB database.
-pub type Protocol = UsbId<PROTOCOL_ID, u8>;
-
-impl Protocol {
-    /// Returns the [`Protocol`] corresponding to the given class, subclass, and protocol IDs,
-    /// or `None` if no such protocol exists in the DB.
-    pub fn from_cid_scid_pid(class_id: u8, subclass_id: u8, id: u8) -> Option<&'static Self> {
-        let subclass = SubClass::from_cid_scid(class_id, subclass_id);
-
-        subclass.and_then(|s| s.protocols().find(|p| p.id == id))
-    }
-}
-
-/// Represents a generic USB ID in the USB database.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct UsbId<const ID: u8, T> {
-    id: T,
-    name: &'static str,
-}
-
-impl<const ID: u8, T: Copy> UsbId<ID, T> {
-    /// Returns the type's ID.
-    pub fn id(&self) -> T {
-        self.id
-    }
-
-    /// Returns the type's name.
-    pub fn name(&self) -> &'static str {
-        self.name
-    }
-}
-
-/// Represents a generic USB ID in the USB database with children IDs.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct UsbIdWithChildren<T: Copy, C: 'static> {
-    id: T,
-    name: &'static str,
-    children: &'static [C],
-}
-
-impl<T: Copy, C: 'static> UsbIdWithChildren<T, C> {
-    /// Returns the type's ID.
-    pub fn id(&self) -> T {
-        self.id
-    }
-
-    /// Returns the type's name.
-    pub fn name(&self) -> &'static str {
-        self.name
-    }
-
-    /// Returns an iterator over the type's children.
-    fn children(&self) -> impl Iterator<Item = &'static C> {
-        self.children.iter()
-    }
-}
-
-/// Represents an audio terminal in the USB database.
-pub type AudioTerminal = UsbId<AT_ID, u16>;
-
-/// Represents a HID descriptor type in the USB database.
-pub type Hid = UsbId<HID_ID, u8>;
-
-/// Represents a HID descriptor item type in the USB database.
-pub type HidItemType = UsbId<HID_TYPE_ID, u8>;
-
-/// Represents a HID usage page in the USB database.
-pub type HidUsagePage = UsbIdWithChildren<u8, HidUsage>;
-
-impl HidUsagePage {
-    /// Returns an iterator over the page's usages.
-    pub fn usages(&self) -> impl Iterator<Item = &'static HidUsage> {
-        self.children()
-    }
-}
-
-/// Represents a HID usage in the USB database.
-pub type HidUsage = UsbId<HID_USAGE_ID, u16>;
-
-impl HidUsage {
-    /// Returns the [`HidUsage`] corresponding to the given usage page and usage ID,
-    /// or `None` if no such usage exists in the DB.
-    pub fn from_pageid_uid(page_id: u8, id: u16) -> Option<&'static Self> {
-        let page = HidUsagePage::from_id(page_id)?;
-
-        page.children().find(|u| u.id() == id)
-    }
-}
-
-/// Physical descriptor bias types
-pub type Bias = UsbId<BIAS_ID, u8>;
-
-/// Physical descriptor item types
-pub type Phy = UsbId<PHY_ID, u8>;
-
-/// Represents a language in the USB database.
-pub type Language = UsbIdWithChildren<u16, Dialect>;
-
-impl Language {
-    /// Returns an iterator over the language's dialects.
-    pub fn dialects(&self) -> impl Iterator<Item = &'static Dialect> {
-        self.children()
-    }
-}
-
-/// Represents a language dialect in the USB database.
-pub type Dialect = UsbId<DIALECT_ID, u8>;
-
-impl Dialect {
-    /// Returns the [`Dialect`] corresponding to the given language and dialect IDs,
-    /// or `None` if no such dialect exists in the DB.
-    pub fn from_lid_did(language_id: u16, id: u8) -> Option<&'static Self> {
-        let language = Language::from_id(language_id)?;
-
-        language.children().find(|d| d.id() == id)
-    }
-}
-
-/// Represents a HID descriptor country code in the USB database.
-pub type HidCountryCode = UsbId<HCC_ID, u8>;
-
-/// Represents a video class terminal type in the USB database.
-pub type VideoTerminal = UsbId<VT_ID, u16>;
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -477,7 +687,10 @@ mod tests {
         assert_eq!(device, device2);
 
         let last_device = Device::from_vid_pid(0xffee, 0x0100).unwrap();
-        assert_eq!(last_device.name(), "Card Reader Controller RTS5101/RTS5111/RTS5116");
+        assert_eq!(
+            last_device.name(),
+            "Card Reader Controller RTS5101/RTS5111/RTS5116"
+        );
     }
 
     #[test]


### PR DESCRIPTION
I started adding just classes: https://github.com/woodruffw/usb-ids.rs/compare/main...tuna-f1sh:usb-ids.rs:classes but decided to continue with feature for full support of all USB IDs.

I shared the original because this is of course a lot more involved and so opinionated perhaps. There were some decisions I've documented regarding the generics and parser state detection but think this is a reasonable working solution.

Closes #2.